### PR TITLE
Bug/parse dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: octopusR
 Title: Interact with the 'Octopus Energy' API
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: 
     person("James", "McMahon", , "jamesmcmahon0@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5380-2029"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     tibble
 Suggests: 
     covr,
+    lubridate,
     spelling,
     testthat
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
-# octopusR (development version)
+# octopusR NEWS
 
-# octopusR 1.0.0
+## Unreleased (2023-05-31)
 
-# octopusR 0.2.0
+Full set of changes:
+[`v1.0.0...2c63fc3`](git@github.com:Moohan/octopusR/compare/v1.0.0...2c63fc3)
 
-# octopusR 0.1.0
+## v1.0.0 (2023-03-07)
 
-# octopusR 0.0.0.9000
-
-* Added a `NEWS.md` file to track changes to the package.
+Full set of changes:
+[`be45be6...v1.0.0`](git@github.com:Moohan/octopusR/compare/be45be6...v1.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# octopusR (development version)
+
 # octopusR 1.0.0
 
 # octopusR 0.2.0

--- a/R/get_consumption.R
+++ b/R/get_consumption.R
@@ -7,8 +7,14 @@
 #' * SMETS1 Secure gas meters: kWh
 #' * SMETS2 gas meters: m^3
 #'
+#' ## Parsing dates
+#' To return dates properly parsed [lubridate][lubridate::lubridate-package] is
+#' required. Use the `tz` parameter to specify a time zone e.g. `tz = "UTC"`,
+#' the default (`tz = NULL`) will return the dates unparsed, as characters.
+#'
 #' @inheritParams set_api_key
 #' @inheritParams set_meter_details
+#' @inheritParams lubridate::ymd_hms
 #' @param period_from Show consumption from the given datetime (inclusive).
 #' This parameter can be provided on its own.
 #' @param period_to Show consumption to the given datetime (exclusive).
@@ -20,7 +26,7 @@
 #' * `period`, to give results ordered forward.
 #' * `-period`, (default), to give results ordered from most recent backwards.
 #' @param group_by Aggregates consumption over a specified time period.
-#' A day is considered to start and end at midnight in the server's timezone.
+#' A day is considered to start and end at midnight in the server's time zone.
 #' The default is that consumption is returned in half-hour periods.
 #' Accepted values are:
 #' * `hour`
@@ -31,119 +37,131 @@
 #'
 #' @return a [tibble][tibble::tibble-package] of the requested consumption data.
 #' @export
-get_consumption <-
-  function(meter_type = c("electricity", "gas"),
-           mpan_mprn = get_meter_details(meter_type)[["mpan_mprn"]],
-           serial_number = get_meter_details(meter_type)[["serial_number"]],
-           api_key = get_api_key(),
-           period_from = NULL,
-           period_to = NULL,
-           order_by = c("-period", "period"),
-           group_by = c("hour", "day", "week", "month", "quarter")) {
-    if (missing(meter_type)) {
-      cli::cli_abort(
-        "You must specify {.val electricity} or {.val gas} for {.arg meter_type}"
-      )
-    }
-    meter_type <- match.arg(meter_type)
-    if (!missing(period_to) && missing(period_from)) {
-      cli::cli_abort(
-        "To use {.arg period_to} you must also provide the {.arg period_from} parameter to create a range."
-      )
-    }
-    if (missing(order_by)) {
-      order_by <- NULL
-    } else {
-      order_by <- match.arg(order_by)
-    }
-    if (missing(group_by)) {
-      group_by <- NULL
-    } else {
-      group_by <- match.arg(group_by)
-    }
+get_consumption <- function(
+    meter_type = c("electricity", "gas"),
+    mpan_mprn = get_meter_details(meter_type)[["mpan_mprn"]],
+    serial_number = get_meter_details(meter_type)[["serial_number"]],
+    api_key = get_api_key(),
+    period_from = NULL,
+    period_to = NULL,
+    tz = NULL,
+    order_by = c("-period", "period"),
+    group_by = c("hour", "day", "week", "month", "quarter")) {
+  if (missing(meter_type)) {
+    cli::cli_abort(
+      "You must specify {.val electricity} or {.val gas} for {.arg meter_type}"
+    )
+  }
+  meter_type <- match.arg(meter_type)
+  if (!missing(period_to) && missing(period_from)) {
+    cli::cli_abort(
+      "To use {.arg period_to} you must also provide the {.arg period_from} parameter to create a range."
+    )
+  }
+  if (missing(order_by)) {
+    order_by <- NULL
+  } else {
+    order_by <- match.arg(order_by)
+  }
+  if (missing(group_by)) {
+    group_by <- NULL
+  } else {
+    group_by <- match.arg(group_by)
+  }
 
-    if (!missing(period_to)) {
-      check_datetime_format(period_to)
-
-      if (missing(period_from)) {
-        cli::cli_abort(
-          "You must also specify {.arg period_to} when specifying {.arg period_from}."
-        )
-      }
-    }
+  if (!missing(period_to)) {
+    check_datetime_format(period_to)
 
     if (missing(period_from)) {
-      page_size <- 100L
-      cli::cli_inform(c(
-        "i" = "Returning 100 rows only as a date range wasn't provided.",
-        "v" = "Specify a date range with {.arg period_to} and {.arg period_from}."
-      ))
-    } else {
-      check_datetime_format(period_from)
-      page_size <- 25000L
+      cli::cli_abort(
+        "You must also specify {.arg period_to} when specifying {.arg period_from}."
+      )
     }
+  }
 
-    path <- glue::glue(
-      "/v1",
-      "{meter_type}-meter-points",
-      mpan_mprn,
-      "meters",
-      serial_number,
-      "consumption",
-      .sep = "/"
-    )
+  if (missing(period_from)) {
+    page_size <- 100L
+    cli::cli_inform(c(
+      "i" = "Returning 100 rows only as a date range wasn't provided.",
+      "v" = "Specify a date range with {.arg period_to} and {.arg period_from}."
+    ))
+  } else {
+    check_datetime_format(period_from)
+    page_size <- 25000L
+  }
 
-    query <- list(
-      period_from = period_from,
-      period_to = period_to,
-      page_size = page_size,
-      order_by = order_by,
-      group_by = group_by
-    )
+  path <- glue::glue(
+    "/v1",
+    "{meter_type}-meter-points",
+    mpan_mprn,
+    "meters",
+    serial_number,
+    "consumption",
+    .sep = "/"
+  )
+
+  query <- list(
+    period_from = period_from,
+    period_to = period_to,
+    page_size = page_size,
+    order_by = order_by,
+    group_by = group_by
+  )
+
+  resp <- octopus_api(
+    path = path,
+    api_key = api_key,
+    query = query
+  )
+
+  consumption_data <- resp[["content"]][["results"]]
+
+  page <- 1L
+  total_rows <- resp[["content"]][["count"]]
+  total_pages <- ceiling(total_rows / page_size)
+
+  cli::cli_progress_bar("Getting consumption data", total = total_pages)
+
+  while (page_size == 2500L && !is.null(resp[["content"]][["next"]])) {
+    page <- page + 1L
 
     resp <- octopus_api(
       path = path,
       api_key = api_key,
-      query = query
+      query = append(query, list("page" = page))
     )
 
-    consumption_data <- resp[["content"]][["results"]]
-
-    page <- 1L
-    total_rows <- resp[["content"]][["count"]]
-    total_pages <- ceiling(total_rows / page_size)
-
-    cli::cli_progress_bar("Getting consumption data", total = total_pages)
-
-    while (page_size == 2500L && !is.null(resp[["content"]][["next"]])) {
-      page <- page + 1L
-
-      resp <- octopus_api(
-        path = path,
-        api_key = api_key,
-        query = append(query, list("page" = page))
-      )
-
-      consumption_data <- rbind(
-        consumption_data,
-        resp[["content"]][["results"]]
-      )
-
-      cli::cli_progress_update()
-    }
-
-    cli::cli_progress_done()
-
-
-    iso_8601_format <- "%Y-%m-%dT%H:%M:%SZ"
-    consumption_data$interval_start <- strptime(
-      consumption_data$interval_start,
-      iso_8601_format
-    )
-    consumption_data$interval_end <- strptime(
-      consumption_data$interval_end,
-      iso_8601_format
+    consumption_data <- rbind(
+      consumption_data,
+      resp[["content"]][["results"]]
     )
 
-    return(consumption_data)
+    cli::cli_progress_update()
   }
+
+  cli::cli_progress_done()
+
+  if (!is.null(tz)) {
+    if (rlang::is_interactive()) {
+      rlang::check_installed(
+        pkg = "lubridate",
+        reason = "to parse dates, use `tz = NULL` to return characters."
+      )
+    } else {
+      if (!rlang::is_installed("lubridate")) {
+        cli::cli_abort("{.pkg lubridate} must be installed to parse dates,
+                       use `tz = NULL` to return characters.")
+      }
+    }
+    consumption_data[["interval_start"]] <- lubridate::ymd_hms(
+      consumption_data[["interval_start"]],
+      tz = tz
+    )
+    consumption_data[["interval_end"]] <- lubridate::ymd_hms(
+      consumption_data[["interval_end"]],
+      tz = tz
+    )
+  }
+
+  return(consumption_data)
+}

--- a/man/get_consumption.Rd
+++ b/man/get_consumption.Rd
@@ -11,6 +11,7 @@ get_consumption(
   api_key = get_api_key(),
   period_from = NULL,
   period_to = NULL,
+  tz = NULL,
   order_by = c("-period", "period"),
   group_by = c("hour", "day", "week", "month", "quarter")
 )
@@ -34,6 +35,9 @@ This parameter can be provided on its own.}
 This parameter also requires providing the \code{period_from} parameter
 to create a range.}
 
+\item{tz}{a character string that specifies which time zone to parse the date with. The string
+must be a time zone that is recognized by the user's OS.}
+
 \item{order_by}{Ordering of results returned. Default is that results are
 returned in reverse order from latest available figure.
 Valid values:
@@ -43,7 +47,7 @@ Valid values:
 }}
 
 \item{group_by}{Aggregates consumption over a specified time period.
-A day is considered to start and end at midnight in the server's timezone.
+A day is considered to start and end at midnight in the server's time zone.
 The default is that consumption is returned in half-hour periods.
 Accepted values are:
 \itemize{
@@ -66,5 +70,11 @@ Unit of measurement:
 \item Electricity meters: kWh
 \item SMETS1 Secure gas meters: kWh
 \item SMETS2 gas meters: m^3
+}
+\subsection{Parsing dates}{
+
+To return dates properly parsed \link[lubridate:lubridate-package]{lubridate} is
+required. Use the \code{tz} parameter to specify a time zone e.g. \code{tz = "UTC"},
+the default (\code{tz = NULL}) will return the dates unparsed, as characters.
 }
 }

--- a/tests/testthat/_snaps/get_consumption.md
+++ b/tests/testthat/_snaps/get_consumption.md
@@ -1,0 +1,48 @@
+# Returned data is consistent
+
+    Code
+      get_consumption(meter_type = "electricity", group_by = "week", period_from = "2022-01-01",
+        period_to = "2022-01-31")
+    Output
+      # A tibble: 6 x 3
+        consumption interval_start       interval_end        
+              <dbl> <chr>                <chr>               
+      1       0.147 2022-01-31T00:00:00Z 2022-01-31T00:30:00Z
+      2      91.2   2022-01-24T00:00:00Z 2022-01-31T00:00:00Z
+      3     137.    2022-01-17T00:00:00Z 2022-01-24T00:00:00Z
+      4      97.4   2022-01-10T00:00:00Z 2022-01-17T00:00:00Z
+      5     125.    2022-01-03T00:00:00Z 2022-01-10T00:00:00Z
+      6      41.8   2022-01-01T00:00:00Z 2022-01-03T00:00:00Z
+
+---
+
+    Code
+      get_consumption(meter_type = "electricity", group_by = "week", period_from = "2022-01-01",
+        period_to = "2022-01-31", tz = "UTC")
+    Output
+      # A tibble: 6 x 3
+        consumption interval_start      interval_end       
+              <dbl> <dttm>              <dttm>             
+      1       0.147 2022-01-31 00:00:00 2022-01-31 00:30:00
+      2      91.2   2022-01-24 00:00:00 2022-01-31 00:00:00
+      3     137.    2022-01-17 00:00:00 2022-01-24 00:00:00
+      4      97.4   2022-01-10 00:00:00 2022-01-17 00:00:00
+      5     125.    2022-01-03 00:00:00 2022-01-10 00:00:00
+      6      41.8   2022-01-01 00:00:00 2022-01-03 00:00:00
+
+---
+
+    Code
+      get_consumption(meter_type = "electricity", group_by = "week", period_from = "2022-01-01",
+        period_to = "2022-01-31", tz = "UTC", order_by = "period")
+    Output
+      # A tibble: 6 x 3
+        consumption interval_start      interval_end       
+              <dbl> <dttm>              <dttm>             
+      1      41.8   2022-01-01 00:00:00 2022-01-03 00:00:00
+      2     125.    2022-01-03 00:00:00 2022-01-10 00:00:00
+      3      97.4   2022-01-10 00:00:00 2022-01-17 00:00:00
+      4     137.    2022-01-17 00:00:00 2022-01-24 00:00:00
+      5      91.2   2022-01-24 00:00:00 2022-01-31 00:00:00
+      6       0.147 2022-01-31 00:00:00 2022-01-31 00:30:00
+

--- a/tests/testthat/test-get_consumption.R
+++ b/tests/testthat/test-get_consumption.R
@@ -27,3 +27,33 @@ test_that("errors properly with incorrect params", {
     "To use `period_to` you must also provide the `period_from` parameter to create a range"
   )
 })
+
+test_that("Returned data is consistent", {
+  expect_snapshot(
+    get_consumption(
+      meter_type = "electricity",
+      group_by = "week",
+      period_from = "2022-01-01",
+      period_to = "2022-01-31"
+    )
+  )
+  expect_snapshot(
+    get_consumption(
+      meter_type = "electricity",
+      group_by = "week",
+      period_from = "2022-01-01",
+      period_to = "2022-01-31",
+      tz = "UTC"
+    )
+  )
+  expect_snapshot(
+    get_consumption(
+      meter_type = "electricity",
+      group_by = "week",
+      period_from = "2022-01-01",
+      period_to = "2022-01-31",
+      tz = "UTC",
+      order_by = "period"
+    )
+  )
+})


### PR DESCRIPTION
This fixes #19. 

The `get_consumption` function now includes a `tz` parameter. By default, this parameter is set to `NULL`, meaning that any dates will be returned as character vectors without any modifications. However, if a timezone is specified (e.g. `tz = "UTC"`), the function will use `lubridate` to convert the character vector into a date variable with the specified timezone.