### PR TITLE
Better error on missing meter

### DIFF
--- a/R/get_consumption.R
+++ b/R/get_consumption.R
@@ -51,8 +51,9 @@ get_consumption <- function(
     cli::cli_abort(
       "You must specify {.val electricity} or {.val gas} for {.arg meter_type}"
     )
+  } else {
+    meter_type <- match.arg(meter_type)
   }
-  meter_type <- match.arg(meter_type)
   if (!missing(period_to) && missing(period_from)) {
     cli::cli_abort(
       "To use {.arg period_to} you must also provide the {.arg period_from} parameter to create a range."

--- a/R/get_consumption.R
+++ b/R/get_consumption.R
@@ -54,6 +54,9 @@ get_consumption <- function(
   } else {
     meter_type <- match.arg(meter_type)
   }
+  force(mpan_mprn)
+  force(serial_number)
+  force(api_key)
   if (!missing(period_to) && missing(period_from)) {
     cli::cli_abort(
       "To use {.arg period_to} you must also provide the {.arg period_from} parameter to create a range."

--- a/R/get_meter_gsp.R
+++ b/R/get_meter_gsp.R
@@ -8,6 +8,13 @@
 #' @return a character of the meter-points GSP.
 #' @export
 get_meter_gsp <- function(mpan = get_meter_details("electricity")[["mpan_mprn"]]) {
+  if (is.na(mpan) || mpan == "") {
+    cli::cli_abort(
+      "Meter details were missing or incomplete, please supply with {.arg mpan_mprn} and {.arg serial_number} arguments or with {.help [{.fun set_meter_details}](octopusR::set_meter_details)}",
+      call = rlang::caller_env()
+    )
+  }
+
   path <- glue::glue(
     "/v1",
     "electricity-meter-points",

--- a/R/meter_details.R
+++ b/R/meter_details.R
@@ -56,7 +56,6 @@ get_meter_details <-
     if (meter_type == "electricity") {
       mpan_mprn <- Sys.getenv("OCTOPUSR_MPAN")
       serial_number <- Sys.getenv("OCTOPUSR_ELEC_SERIAL_NUM")
-      meter_gsp <- get_meter_gsp(mpan = mpan_mprn)
     } else if (meter_type == "gas") {
       mpan_mprn <- Sys.getenv("OCTOPUSR_MPRN")
       serial_number <- Sys.getenv("OCTOPUSR_GAS_SERIAL_NUM")
@@ -68,7 +67,11 @@ get_meter_details <-
           type = meter_type,
           mpan_mprn = mpan_mprn,
           serial_number = serial_number,
-          gsp = ifelse(meter_type == "electricity", meter_gsp, NA)
+          gsp = ifelse(
+            meter_type == "electricity",
+            get_meter_gsp(mpan = mpan_mprn),
+            NA
+          )
         ),
         class = "octopus_meter-point"
       )
@@ -77,7 +80,7 @@ get_meter_details <-
     }
 
     cli::cli_abort(
-      "Meter details were missing or incomplete, please supply with {.arg mpan_mprn} and {.arg serial_number} arguments or with {.help [{.fun set_meter_details}](octopusR::set_meter_details)}",
+      "Meter details were missing or incomplete, please supply with {.arg mpan_mprn} and {.arg serial_number} arguments or with {.help [{.fun set_meter_details}](octopusR::set_meter_details)}.",
       call = rlang::caller_env()
     )
   }

--- a/tests/testthat/test-get_meter_gsp.R
+++ b/tests/testthat/test-get_meter_gsp.R
@@ -14,6 +14,9 @@ test_that("Can get a meter GSP", {
 })
 
 test_that("Fails with bad mprn", {
-  expect_error(get_meter_gsp(mpan = NA), "HTTP 404")
+  expect_error(
+    get_meter_gsp(mpan = NA),
+    "Meter details were missing or incomplete"
+  )
   expect_error(get_meter_gsp(mpan = "123"), "HTTP 404")
 })


### PR DESCRIPTION
Deal with the case where the meter data is missing better. This is mostly about reordering when things are checked, so that the user is presented with an obvious / simpler error.