### PR TITLE
Fix link to API docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Version: 1.0.1.9000
 Authors@R: 
     person("James", "McMahon", , "jamesmcmahon0@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5380-2029"))
-Description: A simple wrapper for the 'Octopus Energy' API
-    <https://developer.octopus.energy/docs/api/>. It handles
+Description: A simple wrapper for the 'Octopus Energy' REST API
+    <https://developer.octopus.energy/rest/>. It handles
     authentication, by storing a provided API key and meter details.
     Implemented endpoints include 'products' for viewing tariff details
     and 'consumption' for viewing meter consumption data.

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,9 +22,9 @@ status](https://www.r-pkg.org/badges/version/octopusR)](https://CRAN.R-project.o
 [![Codecov test coverage](https://codecov.io/gh/Moohan/octopusR/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Moohan/octopusR?branch=main)
 <!-- badges: end -->
 
-octopusR is an R package that provides access to the [Octopus Energy API](https://developer.octopus.energy/docs/api/). With octopusR, you can easily retrieve data from the Octopus Energy API and use it in your R projects, or Shiny dashboards.
+octopusR is an R package that provides access to the [Octopus Energy REST API](https://developer.octopus.energy/rest). With octopusR, you can easily retrieve data from the Octopus Energy API and use it in your R projects, or Shiny dashboards.
 
-If you find this package useful, why not [sponsor me on GitHub](https://github.com/sponsors/Moohan) or [sign up for an Octopus Energy account with my referral code (young-snake-740)](https://share.octopus.energy/young-snake-740)!
+If you find this package useful, why not [sponsor me on GitHub](https://github.com/sponsors/Moohan) or sign up for an Octopus Energy account with [my referral code (young-snake-740)](https://share.octopus.energy/young-snake-740)!
 
 ## Installation
 octopusR can be installed from CRAN.
@@ -35,7 +35,7 @@ install.packages("octopusR")
 
 If you would like the development version, it can be installed from GitHub, using the `devtools` package:
 
-``` r
+```r
 # Install devtools if needed
 if (!require("devtools")) install.packages("devtools")
 devtools::install_github("moohan/octopusR")

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ coverage](https://codecov.io/gh/Moohan/octopusR/branch/main/graph/badge.svg)](ht
 <!-- badges: end -->
 
 octopusR is an R package that provides access to the [Octopus Energy
-API](https://developer.octopus.energy/docs/api/). With octopusR, you can
+REST API](https://developer.octopus.energy/rest). With octopusR, you can
 easily retrieve data from the Octopus Energy API and use it in your R
 projects, or Shiny dashboards.
 
 If you find this package useful, why not [sponsor me on
-GitHub](https://github.com/sponsors/Moohan) or [sign up for an Octopus
-Energy account with my referral code
+GitHub](https://github.com/sponsors/Moohan) or sign up for an Octopus
+Energy account with [my referral code
 (young-snake-740)](https://share.octopus.energy/young-snake-740)!
 
 ## Installation


### PR DESCRIPTION
Octopus Energy now also have a GraphQL API, as well as the REST one that this package uses.