### PR TITLE
Update scorecards.yml to run against PR

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,7 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '20 7 * * 2'
+    - cron: '20 5 * * 0'
+  pull_request:
+    branches: ["main"]
   push:
     branches: ["main"]
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- The CI workflow for scorecards is now triggered on pull requests targeting the `main` branch, in addition to the existing schedule and push events.