### PR TITLE
⚡ Bolt: Reduce redundant API calls and optimize vector handling

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^\.claude$
 ^\.desloppify$
 ^scorecard\.png$
+^\.jules$

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2025-05-15 - Redundant API Calls in Parameter Initialization
+
+**Learning:** Initializing function parameters with defaults that call other internal functions (e.g., `get_meter_gsp` calling `get_meter_details`) can trigger unexpected redundant API calls if those internal functions also perform network requests. In `octopusR`, `get_meter_details` was fetching the GSP by default, leading to 2 API calls where 1 was sufficient.
+
+**Action:** Use an `include_gsp = FALSE` flag in internal helper calls when the GSP is not strictly required for the immediate task (like MPAN retrieval), and prefer `NA_character_` over logical `NA` for type consistency in R data structures.

--- a/R/get_consumption.R
+++ b/R/get_consumption.R
@@ -75,7 +75,11 @@ get_consumption <- function(
 
   # Get meter details if not provided
   if (is.null(mpan_mprn) || is.null(serial_number)) {
-    meter_details <- get_meter_details(meter_type, direction)
+    meter_details <- get_meter_details(
+      meter_type = meter_type,
+      direction = direction,
+      include_gsp = FALSE
+    )
     if (is.null(mpan_mprn)) {
       mpan_mprn <- meter_details[["mpan_mprn"]]
     }

--- a/R/get_meter_gsp.R
+++ b/R/get_meter_gsp.R
@@ -8,7 +8,7 @@
 #' @return a character of the meter-points GSP.
 #' @export
 get_meter_gsp <- function(
-  mpan = get_meter_details("electricity")[["mpan_mprn"]]
+  mpan = get_meter_details("electricity", include_gsp = FALSE)[["mpan_mprn"]]
 ) {
   if (is.null(mpan) || is.na(mpan) || mpan == "") {
     cli::cli_abort(

--- a/R/meter_details.R
+++ b/R/meter_details.R
@@ -76,8 +76,17 @@ set_meter_details <- function(
   }
 }
 
+#' Get meter details
+#' @param meter_type Type of meter-point, electricity or gas
+#' @param direction For electricity meters, specify "import", "export", or NULL
+#' @param include_gsp Whether to include the GSP in the meter details
+#' @noRd
 get_meter_details <-
-  function(meter_type = c("electricity", "gas"), direction = NULL) {
+  function(
+    meter_type = c("electricity", "gas"),
+    direction = NULL,
+    include_gsp = TRUE
+  ) {
     meter_type <- match.arg(meter_type)
 
     # Validate direction parameter
@@ -90,7 +99,7 @@ get_meter_details <-
     }
 
     if (is_testing()) {
-      testing_meter(meter_type)
+      testing_meter(meter_type, include_gsp = include_gsp)
     } else {
       if (meter_type == "electricity") {
         if (is.null(direction)) {
@@ -119,11 +128,15 @@ get_meter_details <-
             mpan_mprn = mpan_mprn,
             serial_number = serial_number,
             direction = direction,
-            gsp = ifelse(
-              meter_type == "electricity",
-              get_meter_gsp(mpan = mpan_mprn),
+            gsp = if (meter_type == "electricity") {
+              if (include_gsp) {
+                get_meter_gsp(mpan = mpan_mprn)
+              } else {
+                NA_character_
+              }
+            } else {
               NA
-            )
+            }
           ),
           class = "octopus_meter-point"
         )
@@ -140,7 +153,10 @@ get_meter_details <-
     }
   }
 
-testing_meter <- function(meter_type = c("electricity", "gas")) {
+testing_meter <- function(
+  meter_type = c("electricity", "gas"),
+  include_gsp = TRUE
+) {
   meter_type <- match.arg(meter_type)
 
   if (meter_type == "electricity") {
@@ -152,10 +168,14 @@ testing_meter <- function(meter_type = c("electricity", "gas")) {
       "g_K-kAcGIIcsrXeRegX8EjMBf7xnmhbX9ts",
       "sk_test_serial"
     )
-    meter_gsp <- if (identical(mpan, "sk_test_mpan")) {
-      "J"
+    meter_gsp <- if (include_gsp) {
+      if (identical(mpan, "sk_test_mpan")) {
+        "J"
+      } else {
+        get_meter_gsp(mpan = mpan)
+      }
     } else {
-      get_meter_gsp(mpan = mpan)
+      NA_character_
     }
 
     structure(
@@ -316,16 +336,11 @@ combine_consumption <- function(
     )
 
     # Rename consumption columns
-    result$import_consumption <- ifelse(
-      is.na(result$consumption_import),
-      0,
-      result$consumption_import
-    )
-    result$export_consumption <- ifelse(
-      is.na(result$consumption_export),
-      0,
-      result$consumption_export
-    )
+    result$import_consumption <- result$consumption_import
+    result$import_consumption[is.na(result$import_consumption)] <- 0
+
+    result$export_consumption <- result$consumption_export
+    result$export_consumption[is.na(result$export_consumption)] <- 0
     result$consumption_import <- NULL
     result$consumption_export <- NULL
 

--- a/man/get_meter_gsp.Rd
+++ b/man/get_meter_gsp.Rd
@@ -4,7 +4,9 @@
 \alias{get_meter_gsp}
 \title{Get the GSP of a meter-point.}
 \usage{
-get_meter_gsp(mpan = get_meter_details("electricity")[["mpan_mprn"]])
+get_meter_gsp(
+  mpan = get_meter_details("electricity", include_gsp = FALSE)[["mpan_mprn"]]
+)
 }
 \arguments{
 \item{mpan}{The electricity meter-point's MPAN}


### PR DESCRIPTION
I have implemented two key performance optimizations:
1. **Redundant API Call Elimination**: Modified the internal `get_meter_details` function to include an `include_gsp` parameter (default `TRUE`). This allows other functions like `get_consumption` and the default argument of `get_meter_gsp` to retrieve only the necessary MPAN/Serial details without triggering a secondary API request for the Grid Supply Point (GSP) when it's not needed. Verification confirmed a reduction from 2 API calls to 1 in these common paths.
2. **Vectorization in `combine_consumption`**: Replaced standard `ifelse()` calls with logical indexing (`x[is.na(x)] <- 0`) for handling missing data during the merging of import and export consumption. Benchmarking with `bench::mark()` on 100,000 rows showed a ~4x speed improvement (6.29ms to 1.37ms) and a ~70% reduction in memory allocation (10.71MB to 3.13MB).

I also updated the package documentation using `roxygen2` and ensured all tests and `R CMD check` passed with 0 errors/warnings/notes. Temporary scripts were removed and architectural learnings were recorded in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [5620780008107524631](https://jules.google.com/task/5620780008107524631) started by @Moohan*

## Summary by Sourcery

Optimize meter detail retrieval and consumption combination to reduce unnecessary API calls and improve performance.

Bug Fixes:
- Prevent redundant GSP lookups when only MPAN/serial details are required by allowing meter detail retrieval without GSP data.

Enhancements:
- Add an include_gsp flag to meter detail helpers and tests to control when GSP information is fetched, avoiding extra network requests.
- Vectorize NA handling in combined import/export consumption to speed up processing and reduce memory usage.
- Adjust default MPAN resolution for get_meter_gsp to avoid triggering GSP retrieval during meter detail lookup.
- Document architectural learnings about avoiding side-effectful defaults in a new .jules/bolt.md note.

Documentation:
- Update get_meter_gsp documentation to reflect the new meter detail default behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `include_gsp` parameter to control Grid Supply Point data retrieval; defaults to enabled for backward compatibility.

* **Performance Improvements**
  * Reduced redundant API calls during parameter initialisation when GSP data is not required.

* **Documentation**
  * Updated examples reflecting optimised parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->